### PR TITLE
Fix #13 Cannot read property 'url'

### DIFF
--- a/src/logic/documentor.js
+++ b/src/logic/documentor.js
@@ -27,12 +27,12 @@ class Documentor {
                 const mapping_key = `${method}:${path}`;
                 this._mapping[mapping_key] = this._mapping[mapping_key] ? this._mapping[mapping_key] : {};
                 for (const code in this._schema.paths[path][method].responses) {
-                        const { content } = this._schema.paths[path][method].responses[code];
-                    if (this._openapi && content) {
-                        const { 'application/json': app_json } = content;
+                    const {content} = this._schema.paths[path][method].responses[code];
+                    if (this._openapi && content){
+                        const {'application/json': app_json} = content;
                         this._mapping[mapping_key][code] = app_json.schema;
                     } else {
-                        const { schema } = this._schema.paths[path][method].responses[code];
+                        const {schema} = this._schema.paths[path][method].responses[code];
                         this._mapping[mapping_key][code] = schema;
                     }
                 }

--- a/src/logic/postman.js
+++ b/src/logic/postman.js
@@ -21,8 +21,8 @@ class Postman {
             console.log(`--USING BAIL: ${this._args.bail}`);
             const command = this._generateCommand();
             try {
-                await child_process.execSync(`newman run ${command}`, { stdio: 'inherit' });
-            } catch (error) { }
+                await child_process.execSync(`newman run ${command}`, {stdio: 'inherit'});
+            } catch (error) {}
         }
     }
     async findWorkspace() {
@@ -110,7 +110,7 @@ class Postman {
         for (const event of item.event) {
             if (event.listen === 'test') {
                 const codes = [];
-                const { exec } = event.script;
+                const {exec} = event.script;
                 for (const code in schema) {
                     this._writeSchemaTest(exec, schema, code, path);
                     codes.push(parseInt(code, 10));


### PR DESCRIPTION
 TypeError: Cannot read property 'url' of undefined #13 

This PR fixes two errors:
TypeError: Cannot destructure property 'application/json' of 'content' as it is undefined.
TypeError: Cannot read properties of undefined (reading 'url')

First occurs if the response content body is not defined (valid OAS3).
Second is from issue #13 